### PR TITLE
Adding sponsorship packages

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -10,6 +10,7 @@
   "components/schedule",
   "components/home",
   "components/sponsors",
+  "components/sponsor-packages",
   "components/ml_form",
   "components/blog",
   "components/tickets",

--- a/_sass/components/sponsor-packages.scss
+++ b/_sass/components/sponsor-packages.scss
@@ -1,0 +1,48 @@
+.hero .packages {
+	background: rgba(0, 0, 0, 0.3);
+	padding: 2em;
+
+	table {
+		border: 0;
+    font-weight: 300;
+
+    col:hover {
+      background: rgba(0,0,0, 0.2);
+    }
+
+		tr {
+
+      &.names {
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        font-weight: bold;
+
+        .price {
+          font-size: 0.85em;
+          color: white;
+          font-weight: 300;
+          letter-spacing: 0;
+        }
+      }
+
+			td {
+			
+				text-align: center;
+        border-bottom: 0;
+
+				&:first-child {
+					text-align: right;
+          font-size: 0.85em;
+					padding-right: 1em;
+
+          &:last-child {
+            padding-top: 2em;
+            text-transform: uppercase;
+            font-weight: bold;
+          }
+				}
+			}
+		}
+	}
+
+}

--- a/sponsor-packges.html
+++ b/sponsor-packges.html
@@ -195,7 +195,7 @@ bodytags: with-hero
       </tr>
     </table>
 
-    <p class="smallprint">✔&nbsp;Included&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;❌&nbsp;Not&nbsp;included<br />* To be provided by sponsors, to be shipped to venue on the day before the conference.<br/>Prices excluding VAT (if applicable). Tickets must be bought before the official deadline. </p>
+    <p class="smallprint">✔&nbsp;Included&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;❌&nbsp;Not&nbsp;included<br />* To be provided by sponsors, to be shipped to venue on the day before the conference.<br/>** A table with space for 5+ Team members to distribute goodies, flyers and present the company and get the participants a chance to get in touch with the team<br/>Prices excluding VAT (if applicable). Tickets must be bought before the official deadline. </p>
   </section>
 </div>
 

--- a/sponsor-packges.html
+++ b/sponsor-packges.html
@@ -1,0 +1,211 @@
+---
+layout: default
+permalink: /sponsoring/packages/
+title: Sponsor packages
+bodytags: with-hero
+---
+
+
+<div class="hero">
+  <section>
+    <h1>RustFest Kiyv 2017</h1>
+    <p>Join the European Rust Community in Kyiv, April 30th</p>
+  </section>
+
+  <section class="packages">
+    <table>
+      <colgroup>
+        <col span="2" style="text-align: right" />
+        <col />
+        <col />
+        <col />
+        <col />
+      </colgroup>
+
+      <tr class="names">
+        <td colspan="2">&nbsp;</td>
+        <td style="color: mediumspringgreen;">Platinum<br /><span class="price">10&nbsp;000€</span></td>
+        <td style="color: gold;">Gold<br /><span class="price">5&nbsp;000€</span></td>
+        <td style="color: deeppink;">Silver<br /><span class="price">2&nbsp;000€</span></td>
+        <td style="color: darkorange;">Bronze<br /><span class="price">1&nbsp;000€</span></td>
+      </tr>
+
+      <tr>
+        <td colspan="2">Registration Passes included</td>
+        <td>10</td>
+        <td>4</td>
+        <td>2</td>
+        <td>1</td>
+      </tr>
+
+      <tr>
+        <td colspan="2">50% discounted passes</td>
+        <td>∞</td>
+        <td>4</td>
+        <td>4</td>
+        <td>2</td>
+      </tr>
+
+      <tr>
+        <td colspan="2">On the Website</td>
+      </tr>
+
+      <tr>
+        <td colspan="2">Your Logo</td>
+        <td>✔</td>
+        <td>✔</td>
+        <td>✔</td>
+        <td>✔</td>
+      </tr>
+
+      <tr>
+        <td colspan="2">Logo on Mainpage</td>
+        <td>✔</td>
+        <td>✔</td>
+        <td>✔</td>
+        <td>❌</td>
+      </tr>
+
+      <tr>
+        <td colspan="2">Detailed Company profile*</td>
+        <td>✔</td>
+        <td>✔</td>
+        <td>❌</td>
+        <td>❌</td>
+      </tr>
+
+      <tr>
+        <td colspan="2">Promotion</td>
+      </tr>
+
+      <tr>
+        <td colspan="2">Mention in TWiRF post</td>
+        <td>✔</td>
+        <td>✔</td>
+        <td>✔</td>
+        <td>❌</td>
+      </tr>
+
+      <tr>
+        <td colspan="2">Blog post on day of Event*</td>
+        <td>✔</td>
+        <td>✔</td>
+        <td>❌</td>
+        <td>❌</td>
+      </tr>
+
+      <tr>
+        <td colspan="2">Logo in every Newsletter email</td>
+        <td>✔</td>
+        <td>❌</td>
+        <td>❌</td>
+        <td>❌</td>
+      </tr>
+
+      <tr>
+        <td colspan="2">Twitter</td>
+      </tr>
+
+      <tr>
+        <td colspan="2">A tweet before before the event</td>
+        <td>✔</td>
+        <td>✔</td>
+        <td>✔</td>
+        <td>✔</td>
+      </tr>
+
+      <tr>
+        <td colspan="2">A "presented by" tweet on the day</td>
+        <td>✔</td>
+        <td>✔</td>
+        <td>❌</td>
+        <td>❌</td>
+      </tr>
+
+      <tr>
+        <td colspan="2">At the conference</td>
+      </tr>
+
+      <tr>
+        <td colspan="2">Space to distribute freebies*</td>
+        <td>✔</td>
+        <td>✔</td>
+        <td>✔</td>
+        <td>✔</td>
+      </tr>
+
+      <tr>
+        <td colspan="2">Conference display stand*</td>
+        <td>✔</td>
+        <td>✔</td>
+        <td>✔</td>
+        <td>❌</td>
+      </tr>
+
+      <tr>
+        <td colspan="2">5-min talk before Keynote</td>
+        <td>✔</td>
+        <td>✔</td>
+        <td>❌</td>
+        <td>❌</td>
+      </tr>
+
+      <tr>
+        <td colspan="2">Dedicated Company Area**</td>
+        <td>✔</td>
+        <td>✔</td>
+        <td>❌</td>
+        <td>❌</td>
+      </tr>
+
+      <tr>
+        <td colspan="2">Banner at Stage*</td>
+        <td>✔</td>
+        <td>❌</td>
+        <td>❌</td>
+        <td>❌</td>
+      </tr>
+
+      <tr>
+        <td colspan="2">Logo on Poster</td>
+        <td>✔</td>
+        <td>❌</td>
+        <td>❌</td>
+        <td>❌</td>
+      </tr>
+
+      <tr>
+        <td colspan="2">Post conference</td>
+      </tr>
+
+      <tr>
+        <td colspan="2">Logo in Video Recording</td>
+        <td>✔</td>
+        <td>✔</td>
+        <td>❌</td>
+        <td>❌</td>
+      </tr>
+
+      <tr>
+        <td colspan="2">Own "presented by" Screen on Video</td>
+        <td>✔</td>
+        <td>❌</td>
+        <td>❌</td>
+        <td>❌</td>
+      </tr>
+    </table>
+
+    <p class="smallprint">✔&nbsp;Included&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;❌&nbsp;Not&nbsp;included<br />* To be provided by sponsors, to be shipped to venue on the day before the conference.<br/>Prices excluding VAT (if applicable). Tickets must be bought before the official deadline. </p>
+  </section>
+</div>
+
+
+<section class="whitewithwheel">
+  <h2>Interested in Sponsoring?</h2>
+  <br />
+  <p>
+    <a class="button" href="mailto:sponsors@rustfest.eu">
+      Email: sponsors@rustfest.eu
+    </a>
+  </p>
+</section>


### PR DESCRIPTION
Here is my first proposal for Sponsorship packages. Rendered it looks like this:

![screen shot 2017-02-26 at 15 58 20-fullpage](https://cloud.githubusercontent.com/assets/40496/23340812/e2438466-fc3c-11e6-9fe2-3de4615a4c7d.png)

Changelog:

 - Made it a webpage
 - Removed Tote-Bag-Stuff (as we didn't provide it)
 - added Video and promotional stuff
 - added more details on On-side-stuff
 - Clarify what the Sponsor provides and what we provide
 - Clarify that all this is VAT excluded
 - resort to make Platinum pop more