### PR TITLE
Responsively embed youtube

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -14,7 +14,8 @@
   "components/ml_form",
   "components/blog",
   "components/tickets",
-  "components/footer"
+  "components/footer",
+  "components/embed"
 ;
 
 .desc {

--- a/_sass/components/_embed.scss
+++ b/_sass/components/_embed.scss
@@ -1,0 +1,22 @@
+.embed {
+  position: relative;
+  display: block;
+  height: 0;
+  padding: 0;
+  overflow: hidden;
+
+  iframe,
+  video {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border: 0
+  }
+}
+
+.ratio-16-9 {
+  padding-bottom: 9 / 16 * 100%;
+}

--- a/index.html
+++ b/index.html
@@ -133,7 +133,9 @@ bodytags: with-hero
   <section>
     <h1>RustFest 2016 - Videos</h1>
     <p>Want to know what RustFest looks like? Check out the recordings from last year's event</p>
-    <iframe width="853" height="480" src="https://www.youtube.com/embed/videoseries?list=PL85XCvVPmGQh8nWR_Z-fTmPGsUWuzb-dn" frameborder="0" allowfullscreen></iframe>
+    <div class="embed ratio-16-9">
+      <iframe src="https://www.youtube.com/embed/videoseries?list=PL85XCvVPmGQh8nWR_Z-fTmPGsUWuzb-dn" frameborder="0" allowfullscreen></iframe>
+    </div>
   </section>
 </div>
 


### PR DESCRIPTION
Makes the embedded Youtube video scale with the width of the page while keeping its aspect ratio. This should make the site a lot nicer on mobile. (Code copied 1:1 from rust.cologne, by the way.)