### PR TITLE
Don't hide navigation bar on start page

### DIFF
--- a/_sass/components/_navigation.scss
+++ b/_sass/components/_navigation.scss
@@ -103,21 +103,9 @@ header.navigation {
 
 .with-hero header.navigation {
   @include wide-device {
-    background-color: transparent;
+    background-color: transparentize($brand_dark_blue, 0.5);
     border-bottom: none;
     position: absolute;
     transition: background-color 0.5s ease;
-
-    nav {
-      opacity: 0;
-      transition: opacity 0.25s ease;
-    }
-
-    &:hover {
-      background-color: transparentize($brand_dark_blue, 0.5);
-      nav {
-        opacity: 1;
-      }
-    }
   }
 }


### PR DESCRIPTION
I only discovered the header navigation by accident and then remembered
that the 2016 site had this 'feature' as well. Seriously, this is not a
good UX.

…but if you can't live with a permanently visible header, feel free to close this PR. 😄