### PR TITLE
Correcting Social Media Links for Manish

### DIFF
--- a/_data/speakers.yml
+++ b/_data/speakers.yml
@@ -6,10 +6,10 @@ manish:
   links:
     - icon: "github"
       title: "manishearth"
-      url:  "https://github.com/Manishearth"
+      link:  "https://github.com/Manishearth"
     - icon: "twitter"
       title: "manishearth"
-      url: "https://twitter.com/manishearth"
+      link: "https://twitter.com/manishearth"
 emily:
   featured: false
   name: "Emily Dunham"

--- a/index.html
+++ b/index.html
@@ -131,7 +131,7 @@ bodytags: with-hero
               <span class="name">{{speaker.name}}</span>
               <ul class="links">
                 {% for link in speaker.links %}
-                  <li><a href="{{link.url}}" target="_blank" title="{{link.title}}">{% include icons/{{link.icon}}.svg %}</a></li>
+                  <li><a href="{{link.link}}" target="_blank" title="{{link.title}}">{% include icons/{{link.icon}}.svg %}</a></li>
                 {% endfor %}
               </ul>
             </div>

--- a/index.html
+++ b/index.html
@@ -131,7 +131,7 @@ bodytags: with-hero
               <span class="name">{{speaker.name}}</span>
               <ul class="links">
                 {% for link in speaker.links %}
-                  <li><a href="{{link.link}}" target="_blank" title="{{link.title}}">{% include icons/{{link.icon}}.svg %}</a></li>
+                  <li><a href="{{link.url}}" target="_blank" title="{{link.title}}">{% include icons/{{link.icon}}.svg %}</a></li>
                 {% endfor %}
               </ul>
             </div>


### PR DESCRIPTION
I saw on website that they are pointing to http://2017.rustfest.eu/ so I think this should fix it.

PS: I wanted to try a fix too, not only to log the bug. 