### PR TITLE
Remove Ryanair, fix Wizz typo

### DIFF
--- a/travel.md
+++ b/travel.md
@@ -14,7 +14,7 @@ permalink: /travel/
 
 ## Getting to Kyiv
 
-Kyiv has two international airports (IEV and KBP), with a few low-cost airlines servicing the city, including Ryanair, WizAir, Norwegian, AirBaltic, and Turkish Airlines. There are non-stop flights from NYC, too.
+Kyiv has two international airports (IEV and KBP), with a few low-cost airlines servicing the city, including WizzAir, Norwegian, AirBaltic, and Turkish Airlines. There are non-stop flights from NYC, too.
 
 For our guests from neighboring countries train may be a more convenient and more affordable alternative. There are overnight trains from Bratislava, Warsaw, Saint-Petersburg, Moscow, Minsk, Belgrade, some of them offer discounts for students and young adults if booked in advance.
 


### PR DESCRIPTION
* Ryanair starts their flights in the autumn of 2017
* Wizz had a missing `z`