### PR TITLE
Extending the ticket sales.

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@ bodytags: with-hero
           <li>✓<span style="text-decoration: line-through"><span class="highlight">Mar 3rd</span>: Open Regular Ticket Sales</span></li>
           <li>✓<span style="text-decoration: line-through"> <span class="highlight">Mar 5th</span>: Close CfP</span></li>
           <li>✓<span style="text-decoration: line-through"> <span class="highlight">Mar 19th</span>: Confirm Speakers</span></li>
-          <li>➨ <span class="highlight">Apr 23rd</span>: Close Ticket Sales</li>
+          <li>➨ <span class="highlight">Apr 29th</span>: Close Ticket Sales</li>
           <li>- <span class="highlight">Apr 30th</span>: Conference</li>
         </ul>
       </div>


### PR DESCRIPTION
Reasons behind the decision:

 1. Some communities that we gave tickets to haven't come back with the list of guests yet. I'm getting them now.
 2. I've been to JavaScript FW Day conference this weekend, promoted RustFest there, a few people should come back and register.
 3. There's still a stream of people who want to by tickets at the very last moment.
 4. Our catering provider is pretty flexible, so we can give them estimate about 2 days before the event.

The change is effective now on ti.to, but we need to update the website to avoid confusion.